### PR TITLE
Add housing stock tile using NIHSLGD data

### DIFF
--- a/create_jsons/read_all_dataportal_tables_in_json_rpc.R
+++ b/create_jsons/read_all_dataportal_tables_in_json_rpc.R
@@ -811,6 +811,98 @@ data <- data.frame(geog_code = rep(json_data$dimension$LGD2014$category$index, l
 
 df_lps = rbind(df_lps, data)
 
+##### housing stock #####
+df_housingstock <- list()
+
+dataset_short <- "HousingStock"
+dataset_long <- "NIHSLGD"
+
+latest_year <- data_portal$dimension$`TLIST(A1)`$category$index[[which(matrices == dataset_long)]] %>% tail(1)
+
+json_data <- json_data_from_rpc(
+  query = paste0(
+    '{
+  "jsonrpc": "2.0",
+  "method": "PxStat.Data.Cube_API.ReadDataset",
+  "params": {
+    "class": "query",
+    "id": [
+      "TLIST(A1)",
+      "ACCTYPE"
+    ],
+    "dimension": {
+      "TLIST(A1)": {
+        "category": {
+          "index": [
+            "', latest_year, '"
+          ]
+        }
+      },
+      "ACCTYPE": {
+        "category": {
+          "index": [
+            "1",
+            "2",
+            "3",
+            "4"
+          ]
+        }
+      }
+    },
+    "extension": {
+      "pivot": null,
+      "codes": false,
+      "language": {
+        "code": "en"
+      },
+      "format": {
+        "type": "JSON-stat",
+        "version": "2.0"
+      },
+      "matrix": "', dataset_long, '"
+    },
+    "version": "2.0"
+  }
+}')
+)
+
+df_meta_data <- rbind(df_meta_data, t(c(
+  dataset = dataset_short,
+  "table_code" = dataset_long,
+  "year" = latest_year,
+  "geog_level" = "lgd",
+  "dataset_url" = paste0("https://data.nisra.gov.uk/table/", dataset_long),
+  "last_updated" = format(substring(updated[which(matrices == dataset_long)], 1, 10), format = "%a"),
+  "email" = json_data$extension$contact$email,
+  "title" = data_portal$label[which(matrices == dataset_long)],
+  "note" = json_data$note
+)))
+
+categories <- unlist(json_data$dimension$ACCTYPE$category$label)
+
+geog_codes <- c()
+
+for (i in 1:length(json_data$dimension$LGD2014$category$index)) {
+  geog_codes <- c(
+    geog_codes,
+    rep(json_data$dimension$LGD2014$category$index[i], length(categories))
+  )
+}
+
+data <- data.frame(geog_code = geog_codes) %>%
+  mutate(
+    statistic = rep_len(categories, nrow(.)),
+    VALUE = json_data$value
+  ) %>%
+  group_by(geog_code) %>%
+  mutate(
+    perc = VALUE / sum(VALUE) * 100,
+    source = dataset_short
+  ) %>%
+  arrange(geog_code, statistic)
+
+df_housingstock <- rbind(df_housingstock, data)
+
 #### Health ####
 ##### LE #####
 ###### LE by DEA ######
@@ -5167,7 +5259,8 @@ df_dp_all_values <- unique(bind_rows(
 
 df_dp_all_text <- bind_rows(df_admissions_top, df_crime_text, df_env_problems)
 
-df_dp_all_perc <- unique(rbind( df_lmr_perc, df_indust, df_school_perc, df_popage, 
+df_dp_all_perc <- unique(rbind( df_lmr_perc, df_indust, df_school_perc, df_popage,
+                                df_housingstock, 
                                 df_school_destination_perc, df_env_perc, df_business_perc, 
                                 df_crime_perc, df_business_perc_niets))
 

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -164,6 +164,13 @@ export const topics = {
 		{ category: 'Age 65+', label: '65+' }
 	],
 
+	HousingStock: [
+		{ category: 'Apartment', label: 'Apartment' },
+		{ category: 'Detached', label: 'Detached' },
+		{ category: 'Semi-Detached', label: 'Semi-Detached' },
+		{ category: 'Terrace', label: 'Terrace' }
+	],
+
 	age: [
 		{ category: 'a0to14', label: '0-14' },
 		{ category: 'a15to39', label: '15-39' },

--- a/src/lib/layout/IButton.svelte
+++ b/src/lib/layout/IButton.svelte
@@ -308,6 +308,15 @@ function get_i_button_info () {
 				  "<p class = 'pibutton'>Last updated:" + checkMeta("houseprices[0].last_updated") + ".</p>"+
 				  "<p class = 'pibutton'><a href='mailto:" + checkMeta("houseprices[0].email") + "'>Email for more information</a> </p>"  
 		},
+
+		housingstock: {
+			title: "Housing stock",
+			info:
+				" <p class = 'pibutton'>Access data at: <a href='" + checkMeta("HousingStock[0].dataset_url") + "'>" + checkMeta("HousingStock[0].title") + "</a></p>"+
+				"<p class = 'pibutton'>Last updated: " + checkMeta("HousingStock[0].last_updated") + ".</p>"+
+				"<p class = 'pibutton'><a href='mailto:" + checkMeta("HousingStock[0].email") + "'>Email for more information</a> </p>"
+		},
+
 		concern: {
 			title: "Concern about the environment",
 			info:  " <p class = 'pibutton'>Access data at: <a href='" + checkMeta("Env_concern[0].dataset_url") + "'>" + checkMeta("Env_concern[0].title") + "</a></p>"+

--- a/src/routes/[code]/+page.svelte
+++ b/src/routes/[code]/+page.svelte
@@ -1012,8 +1012,7 @@ function compareDensity (place) {
 						year: pullCensusYear("mainlang"),
 						content: "GroupChart",
 						chart_data: makeDataNICompare("mainlang")
-					 }
-					,
+					},
 
 					box_6: {
 						id: "houseprices",
@@ -1039,9 +1038,23 @@ function compareDensity (place) {
 						show: ["dea","sdz","dz"],
 						i_button: false,
 						title: "<span style='font-size: 0.88em'>Average house price</span>"
-					}
+					},
 
-				
+					box_7: {
+						id: "housingstock",
+						year: pullYear("HousingStock", data.place),
+						content: "GroupChart",
+						chart_data: makeDataNICompare("HousingStock"),
+						show: ["ni", "lgd"]
+					},
+
+					box_7a: {
+						id: "housingstock",
+						content: "Data is available for " + parentlinks(data.place, "ni, lgd"),
+						show: ["dea", "sdz", "dz"],
+						i_button: false,
+						title: "Housing stock"
+					}
 
 			}}
 			more = "More information on the size of the population is available in the latest <a href='https://www.nisra.gov.uk/publications/2022-mid-year-population-estimates-northern-ireland'>mid-year estimates release</a>, 


### PR DESCRIPTION
Adds a Housing Stock tile to the Housing section using the NIHSLGD dataset.

The tile:

displays Apartment, Detached, Semi-Detached and Terrace percentages;
compares LGD values with Northern Ireland;
includes dataset metadata via the information button; and
displays the existing-style data availability message for geographies below LGD.

The JSON generation pipeline has been updated to retrieve Housing Stock data through the JSON-RPC API.

Tested locally across NI, LGD and lower geography levels. npm run build completes successfully.

**One important point for the PR/reviewer: the generated github_action_jsons files aren't included in this commit. That's intentional based on our cleanup; the pipeline/source change is what we're submitting.**